### PR TITLE
chore: powertools version update, removed reduntant logevent flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "serverless-typescript-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-lambda-powertools/logger": "^0.11.1-rc.0",
-        "@aws-lambda-powertools/metrics": "^0.11.1-rc.0",
-        "@aws-lambda-powertools/tracer": "^0.11.1-rc.0",
+        "@aws-lambda-powertools/logger": "^1.0.1",
+        "@aws-lambda-powertools/metrics": "^1.0.1",
+        "@aws-lambda-powertools/tracer": "^1.0.1",
         "@aws-sdk/client-dynamodb": "^3.44.0",
         "@aws-sdk/lib-dynamodb": "^3.44.0",
         "@middy/core": "^3.1.0",
@@ -111,35 +111,35 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "0.11.1-rc.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.11.1-rc.0.tgz",
-      "integrity": "sha512-KDtuF0BQ9wEeueKu4W/pOJ3ZkA56xMpeLewonxkiDXUe8xUlh3R5h29I/OzWXBxzH2gdGipPLNBk29ggdF3h9g=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-1.0.1.tgz",
+      "integrity": "sha512-XcTdczAJL4Z/cqErYkOJYcHt0s4hgOD6YiKtsA9GVKpjkquFZJE9yoRGiOnlwlyhOF7+b5OnZoMbj1QKn2effQ=="
     },
     "node_modules/@aws-lambda-powertools/logger": {
-      "version": "0.11.1-rc.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.11.1-rc.0.tgz",
-      "integrity": "sha512-tO6N2kmaNZqtvS5zWXQp0Lllw3w30GyK69HuhCOti9j7eaHlrgRkO4gBSJLcda6ZbQE2zfe460HXYSWa/g7TDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-1.0.1.tgz",
+      "integrity": "sha512-qoCooQWdH82Pm4YdhVBk2CZYCY8haCj3vTrtLgJoKzGqCyc0kmlDmzVNj91uloB2n3+obFJe9dmYEKRJfCYFqg==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.11.1-rc.0",
+        "@aws-lambda-powertools/commons": "^1.0.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0"
       }
     },
     "node_modules/@aws-lambda-powertools/metrics": {
-      "version": "0.11.1-rc.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.11.1-rc.0.tgz",
-      "integrity": "sha512-o0r6kP6Y4pI7naHNsLrs3WmR78xAS+YUu2eREjP7/n1iy52sfakZIujlVPrdiBV+pLb417klEL9u9xKEQTlObA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-1.0.1.tgz",
+      "integrity": "sha512-Cdtq1HOsboJYlM0LtHAogXJLhhid8HPxbu6x3aI8tvlk+rs1pG0yrasM7yrworummvk6qFF9G2Jjti0suLknAg==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.11.1-rc.0"
+        "@aws-lambda-powertools/commons": "^1.0.1"
       }
     },
     "node_modules/@aws-lambda-powertools/tracer": {
-      "version": "0.11.1-rc.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.11.1-rc.0.tgz",
-      "integrity": "sha512-CLI3pFdKOnp/bltNDNceU883ARr7Fkf31BLulaNv0BTp0IcJVSZYDIjqrgDmifB7/XXjaZ+DOwLH8XIaFTxD1w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-1.0.1.tgz",
+      "integrity": "sha512-3F3N3cz5hXsII/LcW0RQIvfB9G/g/WYyA1C/B/+Iz1ZVPDqs33RWIvK+X/dgXlvUeG/LwrxVSAKj6MVcaFy3NQ==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^0.11.1-rc.0",
+        "@aws-lambda-powertools/commons": "^1.0.1",
         "aws-xray-sdk-core": "^3.3.6"
       }
     },
@@ -7271,35 +7271,35 @@
       }
     },
     "@aws-lambda-powertools/commons": {
-      "version": "0.11.1-rc.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-0.11.1-rc.0.tgz",
-      "integrity": "sha512-KDtuF0BQ9wEeueKu4W/pOJ3ZkA56xMpeLewonxkiDXUe8xUlh3R5h29I/OzWXBxzH2gdGipPLNBk29ggdF3h9g=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-1.0.1.tgz",
+      "integrity": "sha512-XcTdczAJL4Z/cqErYkOJYcHt0s4hgOD6YiKtsA9GVKpjkquFZJE9yoRGiOnlwlyhOF7+b5OnZoMbj1QKn2effQ=="
     },
     "@aws-lambda-powertools/logger": {
-      "version": "0.11.1-rc.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-0.11.1-rc.0.tgz",
-      "integrity": "sha512-tO6N2kmaNZqtvS5zWXQp0Lllw3w30GyK69HuhCOti9j7eaHlrgRkO4gBSJLcda6ZbQE2zfe460HXYSWa/g7TDQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-1.0.1.tgz",
+      "integrity": "sha512-qoCooQWdH82Pm4YdhVBk2CZYCY8haCj3vTrtLgJoKzGqCyc0kmlDmzVNj91uloB2n3+obFJe9dmYEKRJfCYFqg==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.11.1-rc.0",
+        "@aws-lambda-powertools/commons": "^1.0.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.merge": "^4.6.2",
         "lodash.pickby": "^4.6.0"
       }
     },
     "@aws-lambda-powertools/metrics": {
-      "version": "0.11.1-rc.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-0.11.1-rc.0.tgz",
-      "integrity": "sha512-o0r6kP6Y4pI7naHNsLrs3WmR78xAS+YUu2eREjP7/n1iy52sfakZIujlVPrdiBV+pLb417klEL9u9xKEQTlObA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-1.0.1.tgz",
+      "integrity": "sha512-Cdtq1HOsboJYlM0LtHAogXJLhhid8HPxbu6x3aI8tvlk+rs1pG0yrasM7yrworummvk6qFF9G2Jjti0suLknAg==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.11.1-rc.0"
+        "@aws-lambda-powertools/commons": "^1.0.1"
       }
     },
     "@aws-lambda-powertools/tracer": {
-      "version": "0.11.1-rc.0",
-      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-0.11.1-rc.0.tgz",
-      "integrity": "sha512-CLI3pFdKOnp/bltNDNceU883ARr7Fkf31BLulaNv0BTp0IcJVSZYDIjqrgDmifB7/XXjaZ+DOwLH8XIaFTxD1w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-1.0.1.tgz",
+      "integrity": "sha512-3F3N3cz5hXsII/LcW0RQIvfB9G/g/WYyA1C/B/+Iz1ZVPDqs33RWIvK+X/dgXlvUeG/LwrxVSAKj6MVcaFy3NQ==",
       "requires": {
-        "@aws-lambda-powertools/commons": "^0.11.1-rc.0",
+        "@aws-lambda-powertools/commons": "^1.0.1",
         "aws-xray-sdk-core": "^3.3.6"
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-lambda-powertools/logger": "^0.11.1-rc.0",
-    "@aws-lambda-powertools/metrics": "^0.11.1-rc.0",
-    "@aws-lambda-powertools/tracer": "^0.11.1-rc.0",
+    "@aws-lambda-powertools/logger": "^1.0.1",
+    "@aws-lambda-powertools/metrics": "^1.0.1",
+    "@aws-lambda-powertools/tracer": "^1.0.1",
     "@aws-sdk/client-dynamodb": "^3.44.0",
     "@aws-sdk/lib-dynamodb": "^3.44.0",
     "@middy/core": "^3.1.0",

--- a/src/api/delete-product.ts
+++ b/src/api/delete-product.ts
@@ -54,8 +54,8 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
 
 const handler = middy(lambdaHandler)
     .use(captureLambdaHandler(tracer))
-    .use(logMetrics(metrics))
-    .use(injectLambdaContext(logger, { clearState: true, logEvent: true }));
+    .use(logMetrics(metrics, { captureColdStartMetric: true }))
+    .use(injectLambdaContext(logger, { clearState: true }));
 
 export {
   handler

--- a/src/api/get-product.ts
+++ b/src/api/get-product.ts
@@ -63,8 +63,8 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
 
 const handler = middy(lambdaHandler)
     .use(captureLambdaHandler(tracer))
-    .use(logMetrics(metrics))
-    .use(injectLambdaContext(logger, { clearState: true, logEvent: true }));
+    .use(logMetrics(metrics, { captureColdStartMetric: true }))
+    .use(injectLambdaContext(logger, { clearState: true }));
 
 export {
   handler

--- a/src/api/get-products.ts
+++ b/src/api/get-products.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
+// blob/main/src/api/get-products.ts
 import { APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import { DynamoDbStore } from "../store/dynamodb/dynamodb-store";
 import { ProductStore } from "../store/product-store";
@@ -28,7 +29,7 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
       body: `{"products":${JSON.stringify(result)}}`,
     };
   } catch (error) {
-      logger.info('Unexpected error occurred while trying to retrieve products', error);
+      logger.error('Unexpected error occurred while trying to retrieve products', error as Error);
 
       return {
         statusCode: 500,
@@ -40,8 +41,8 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
 
 const handler = middy(lambdaHandler)
     .use(captureLambdaHandler(tracer))
-    .use(logMetrics(metrics))
-    .use(injectLambdaContext(logger, { clearState: true, logEvent: true }));
+    .use(logMetrics(metrics, { captureColdStartMetric: true }))
+    .use(injectLambdaContext(logger, { clearState: true }));
 
 export {
   handler

--- a/src/api/put-product.ts
+++ b/src/api/put-product.ts
@@ -95,8 +95,8 @@ const lambdaHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPro
 
 const handler = middy(lambdaHandler)
     .use(captureLambdaHandler(tracer))
-    .use(logMetrics(metrics))
-    .use(injectLambdaContext(logger, { clearState: true, logEvent: true }));
+    .use(logMetrics(metrics, { captureColdStartMetric: true }))
+    .use(injectLambdaContext(logger, { clearState: true }));
 
 export {
   handler


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

- Bump of version of AWS Lambda Powertools for TypeScript utilities
- Removed redundant "logEvent" flag


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
